### PR TITLE
TST: Remove macos-13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,8 +182,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
             target: aarch64
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down

p.s. If you edit the workflow using GH UI, it highlights "platform" as syntax error, but fixing that is out of scope here.