### PR TITLE
align orientation such that a polygon MUST always be counterclockwise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sphersgeo"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 description = "object-oriented spherical geometry"
 readme = "README.md"
 repository = "https://github.com/spacetelescope/sphersgeo"

--- a/changes/10.breaking.rst
+++ b/changes/10.breaking.rst
@@ -1,0 +1,1 @@
+orientation of polygons must now be counterclockwise, such that the inside of the polygon is always to the left of the boundary

--- a/src/arcstring.rs
+++ b/src/arcstring.rs
@@ -4,8 +4,9 @@ use crate::{
         GeometricOperations, GeometricRelationships, Geometry, GeometryCollection, MultiGeometry,
     },
     sphericalpoint::{
-        arc_distance_over_sphere_radians, point_within_kdtree, xyz_add_xyz, xyz_cross, xyz_div_f64,
-        xyz_dot, xyz_eq, xyz_neg, xyzs_collinear, MultiSphericalPoint, SphericalPoint,
+        MultiSphericalPoint, SphericalPoint, arc_distance_over_sphere, point_within_kdtree,
+        xyz_add_xyz, xyz_cross, xyz_div_f64, xyz_dot, xyz_eq, xyz_mul_xyz, xyz_neg, xyz_sub_xyz,
+        xyz_sum, xyzs_colinear,
     },
 };
 use std::{
@@ -18,29 +19,29 @@ use std::{
 use pyo3::prelude::*;
 
 #[cfg(feature = "ndarray")]
-use numpy::ndarray::{concatenate, s, Array2, ArrayView2, Axis};
+use numpy::ndarray::{Array2, ArrayView2, Axis, concatenate, s};
 
-/// Given xyz vectors of the endpoints of two great circle arcs, find the point at which the arcs cross
+/// Given xyz vectors of two great circle arcs, find the point at which the arcs cross
 ///
 /// References
 /// ----------
 /// - Method explained in an `e-mail <http://www.mathworks.com/matlabcentral/newsreader/view_thread/276271>`_ by Roger Stafford.
 /// - https://spherical-geometry.readthedocs.io/en/latest/api/spherical_geometry.great_circle_arc.intersection.html#rb82e4e1c8654-1
 /// - Spinielli, Enrico. 2014. “Understanding Great Circle Arcs Intersection Algorithm.” October 19, 2014. https://enrico.spinielli.net/posts/2014-10-19-understanding-great-circle-arcs.
-pub fn xyz_two_arc_crossing(
-    a: (&[f64; 3], &[f64; 3]),
-    b: (&[f64; 3], &[f64; 3]),
+pub fn arcs_crossing(
+    arc_a: (&[f64; 3], &[f64; 3]),
+    arc_b: (&[f64; 3], &[f64; 3]),
 ) -> Option<[f64; 3]> {
-    let p = xyz_cross(a.0, a.1);
-    let q = xyz_cross(b.0, b.1);
+    let p = xyz_cross(arc_a.0, arc_a.1);
+    let q = xyz_cross(arc_b.0, arc_b.1);
 
     let t = xyz_cross(&p, &q);
 
     let result = [
-        xyz_dot(&xyz_neg(&xyz_cross(a.0, &p)), &t),
-        xyz_dot(&xyz_cross(a.1, &p), &t),
-        xyz_dot(&xyz_neg(&xyz_cross(b.0, &q)), &t),
-        xyz_dot(&xyz_cross(b.1, &q), &t),
+        xyz_dot(&xyz_neg(&xyz_cross(arc_a.0, &p)), &t),
+        xyz_dot(&xyz_cross(arc_a.1, &p), &t),
+        xyz_dot(&xyz_neg(&xyz_cross(arc_b.0, &q)), &t),
+        xyz_dot(&xyz_cross(arc_b.1, &q), &t),
     ];
 
     if result.iter().all(|result| result.is_sign_positive()) {
@@ -52,17 +53,21 @@ pub fn xyz_two_arc_crossing(
     }
 }
 
-pub fn arc_crosses_arcstring(arc: (&[f64; 3], &[f64; 3]), arcstring: &ArcString) -> bool {
-    for other_arc_index in 0..arcstring.points.len() - if arcstring.closed { 0 } else { 1 } {
+pub fn arc_crossings_with_arcstring(
+    arc: (&[f64; 3], &[f64; 3]),
+    arcstring: &ArcString,
+) -> Option<Vec<[f64; 3]>> {
+    let mut crossings = vec![];
+    for other_arc_index in 0..arcstring.points.xyzs.len() - if arcstring.closed { 0 } else { 1 } {
         let other_arc = (
             &arcstring.points.xyzs[other_arc_index],
-            &arcstring.points.xyzs[if other_arc_index < arcstring.points.len() - 1 {
+            &arcstring.points.xyzs[if other_arc_index < arcstring.points.xyzs.len() - 1 {
                 other_arc_index + 1
             } else {
                 0
             }],
         );
-        if let Some(point) = xyz_two_arc_crossing(arc, other_arc) {
+        if let Some(point) = arcs_crossing(arc, other_arc) {
             if xyz_eq(&point, arc.0)
                 || xyz_eq(&point, arc.1)
                 || xyz_eq(&point, other_arc.0)
@@ -70,15 +75,33 @@ pub fn arc_crosses_arcstring(arc: (&[f64; 3], &[f64; 3]), arcstring: &ArcString)
             {
                 continue;
             } else {
-                return true;
+                crossings.push(point);
             }
         }
     }
 
-    false
+    if !crossings.is_empty() {
+        Some(crossings)
+    } else {
+        None
+    }
 }
 
-pub fn xyz_in_arcstring(xyz: &[f64; 3], arcstring: &ArcString) -> bool {
+/// whether two points are on the same side of an arcstring
+///
+/// uses the classical even-crossings algorithm;
+/// if the number of crossings between the arc and the arcstring is even,
+/// then the two points are on the same side of the arcstring
+pub fn points_are_on_same_side(
+    point_a: &[f64; 3],
+    point_b: &[f64; 3],
+    arcstring: &ArcString,
+) -> bool {
+    arc_crossings_with_arcstring((point_a, point_b), arcstring)
+        .map_or(true, |crossings| crossings.len() % 2 == 0)
+}
+
+pub fn point_is_along_arcstring(xyz: &[f64; 3], arcstring: &ArcString) -> bool {
     let xyzs = &arcstring.points.xyzs;
 
     // check if point is one of the vertices of this linestring
@@ -86,7 +109,7 @@ pub fn xyz_in_arcstring(xyz: &[f64; 3], arcstring: &ArcString) -> bool {
         return true;
     }
 
-    // iterate over individual arcs and check if the given point is collinear with their endpoints
+    // iterate over individual arcs and check if the given point is colinear with their endpoints
     for arc_index in 0..xyzs.len() - if arcstring.closed { 0 } else { 1 } {
         let arc_0 = xyzs[arc_index];
         let arc_1 = xyzs[if arc_index < xyzs.len() - 1 {
@@ -95,7 +118,7 @@ pub fn xyz_in_arcstring(xyz: &[f64; 3], arcstring: &ArcString) -> bool {
             0
         }];
 
-        if xyzs_collinear(&arc_0, xyz, &arc_1) {
+        if xyzs_colinear(&arc_0, xyz, &arc_1) {
             return true;
         }
     }
@@ -118,8 +141,8 @@ pub fn split_arc_at_points<'a>(
                 continue;
             }
 
-            if xyzs_collinear(arc_0, point, arc_1) {
-                // replace arc with the arc split in two at the collinear point
+            if xyzs_colinear(arc_0, point, arc_1) {
+                // replace arc with the arc split in two at the colinear point
                 arcs[arc_index] = vec![arcs[arc_index][0], point];
                 arcs.insert(arc_index + 1, vec![point, arcs[arc_index][1]]);
             }
@@ -146,17 +169,17 @@ pub fn split_arcstring_at_points(arcstring: &ArcString, points: Vec<&[f64; 3]>) 
                 let arc_0 = arcstring.points.xyzs[arc_a_index];
                 let arc_1 = arcstring.points.xyzs[arc_b_index];
 
-                if xyzs_collinear(&arc_0, point, &arc_1) {
-                    // replace arc with the arc split in two at the collinear point
+                if xyzs_colinear(&arc_0, point, &arc_1) {
+                    // replace arc with the arc split in two at the colinear point
 
-                    // add the first segment up to the collinear point
+                    // add the first segment up to the colinear point
                     let mut a = vec![];
                     a.extend_from_slice(&arcstring.points.xyzs[..arc_a_index + 1]);
                     a.push(**point);
                     arcstrings[arcstring_index] =
                         ArcString::try_from(MultiSphericalPoint::try_from(a).unwrap()).unwrap();
 
-                    // add the second segment starting from the collinear point
+                    // add the second segment starting from the colinear point
                     let mut b = vec![**point];
                     if arc_b_index > 0 {
                         b.extend_from_slice(&arcstring.points.xyzs[arc_b_index..]);
@@ -185,11 +208,57 @@ pub fn split_arcstring_at_points(arcstring: &ArcString, points: Vec<&[f64; 3]>) 
 /// References
 /// ----------
 /// - https://stackoverflow.com/a/1302268
-fn arc_radians_over_sphere_to_point(a: &[f64; 3], b: &[f64; 3], xyz: &[f64; 3]) -> f64 {
+fn arc_closest_distance_to_point(a: &[f64; 3], b: &[f64; 3], xyz: &[f64; 3]) -> ([f64; 3], f64) {
     let g = xyz_cross(a, b);
     let f = xyz_cross(xyz, &g);
     let t = xyz_cross(&g, &f);
-    arc_distance_over_sphere_radians(&t, xyz)
+    (t, arc_distance_over_sphere(&t, xyz))
+}
+
+/// Inner products of the normal vectors at each vertex of the given arcstring.
+///
+/// Normal vectors point into the sphere if the angle is clockwise and outward if counter-clockwise.
+/// Thus, a negative inner product is a right turn, and positive is left.
+///
+/// If the arcstring is NOT closed the first and last vertices do NOT have turn orientations.
+pub fn xyzs_turn_orientations(xyzs: &[[f64; 3]], closed: bool) -> Vec<f64> {
+    (0..xyzs.len())
+        .map(|index| {
+            // if the arcstring is not closed, the first and last points have no turning angle
+            if !closed && (index == 0 || index == xyzs.len() - 1) {
+                f64::NAN
+            } else {
+                let a = xyzs[if index > 0 { index - 1 } else { xyzs.len() - 1 }];
+                let b = xyzs[index];
+                let c = xyzs[if index < xyzs.len() - 1 { index + 1 } else { 0 }];
+
+                xyz_sum(&xyz_mul_xyz(
+                    &b,
+                    &xyz_cross(&xyz_sub_xyz(&a, &b), &xyz_sub_xyz(&c, &b)),
+                ))
+            }
+        })
+        .collect()
+}
+
+/// Angle in radians at each vertex of the given arcstring (the smaller angle regardless of turn orientation).
+///
+/// If the arcstring is NOT closed the first and last vertices do NOT have angles.
+pub fn xyzs_turn_angles(xyzs: &[[f64; 3]], closed: bool) -> Vec<f64> {
+    (0..xyzs.len())
+        .map(|index| {
+            // if the arcstring is not closed, the first and last points have no turning angle
+            if !closed && (index == 0 || index == xyzs.len() - 1) {
+                f64::NAN
+            } else {
+                let a = xyzs[if index > 0 { index - 1 } else { xyzs.len() - 1 }];
+                let b = xyzs[index];
+                let c = xyzs[if index < xyzs.len() - 1 { index + 1 } else { 0 }];
+
+                crate::sphericalpoint::xyz_two_arc_angle(&a, &b, &c)
+            }
+        })
+        .collect()
 }
 
 /// series of great circle arcs along the sphere
@@ -309,16 +378,13 @@ impl ArcString {
     pub fn lengths(&self) -> Vec<f64> {
         let mut lengths = (0..self.points.len() - 1)
             .map(|index| {
-                arc_distance_over_sphere_radians(
-                    &self.points.xyzs[index],
-                    &self.points.xyzs[index + 1],
-                )
+                arc_distance_over_sphere(&self.points.xyzs[index], &self.points.xyzs[index + 1])
             })
             .collect::<Vec<f64>>();
 
         if self.closed {
             // if the arcstring is closed, also add the length of the final closing arc
-            lengths.push(arc_distance_over_sphere_radians(
+            lengths.push(arc_distance_over_sphere(
                 &self.points.xyzs[self.points.len() - 1],
                 &self.points.xyzs[0],
             ));
@@ -407,7 +473,7 @@ impl ArcString {
                             0
                         }],
                     );
-                    if let Some(point) = xyz_two_arc_crossing(arc, other_arc) {
+                    if let Some(point) = arcs_crossing(arc, other_arc) {
                         if xyz_eq(&point, arc.0)
                             || xyz_eq(&point, arc.1)
                             || xyz_eq(&point, other_arc.0)
@@ -446,7 +512,7 @@ impl ArcString {
                         &self.points.xyzs[other_arc_index + 1],
                     );
 
-                    if let Some(point) = xyz_two_arc_crossing(arc, other_arc) {
+                    if let Some(point) = arcs_crossing(arc, other_arc) {
                         if xyz_eq(&point, arc.0)
                             || xyz_eq(&point, arc.1)
                             || xyz_eq(&point, other_arc.0)
@@ -523,7 +589,7 @@ impl ArcString {
                     self.points.xyzs.len() - index + 1
                 }];
 
-                if xyzs_collinear(&a, &b, &c) {
+                if xyzs_colinear(&a, &b, &c) {
                     unecessary_indices.push(index);
                 }
             }
@@ -552,13 +618,13 @@ impl PartialEq for ArcString {
         };
 
         for xyz in &longer.points.xyzs {
-            if !xyz_in_arcstring(xyz, shorter) {
+            if !point_is_along_arcstring(xyz, shorter) {
                 return false;
             }
         }
 
         for xyz in &shorter.points.xyzs {
-            if !xyz_in_arcstring(xyz, longer) {
+            if !point_is_along_arcstring(xyz, longer) {
                 return false;
             }
         }
@@ -648,7 +714,7 @@ impl GeometricRelationships<SphericalPoint> for ArcString {
     }
 
     fn covers(&self, other: &SphericalPoint) -> bool {
-        xyz_in_arcstring(&other.xyz, self)
+        point_is_along_arcstring(&other.xyz, self)
     }
 }
 
@@ -660,21 +726,25 @@ impl GeometricOperations<SphericalPoint> for ArcString {
     fn distance(&self, other: &SphericalPoint) -> f64 {
         let mut distances = (0..self.points.len() - 1)
             .map(|index| {
-                arc_radians_over_sphere_to_point(
+                arc_closest_distance_to_point(
                     &self.points.xyzs[index],
                     &self.points.xyzs[index + 1],
                     &other.xyz,
                 )
+                .1
             })
             .collect::<Vec<f64>>();
 
         if self.closed {
             // if the arcstring is closed, also add the midpoint of the final closing arc
-            distances.push(arc_radians_over_sphere_to_point(
-                &self.points.xyzs[self.points.len() - 1],
-                &self.points.xyzs[0],
-                &other.xyz,
-            ));
+            distances.push(
+                arc_closest_distance_to_point(
+                    &self.points.xyzs[self.points.len() - 1],
+                    &self.points.xyzs[0],
+                    &other.xyz,
+                )
+                .1,
+            );
         }
 
         match distances.iter().min_by(|a, b| a.partial_cmp(b).unwrap()) {
@@ -725,7 +795,7 @@ impl GeometricRelationships<MultiSphericalPoint> for ArcString {
 
     fn covers(&self, other: &MultiSphericalPoint) -> bool {
         for xyz in &other.xyzs {
-            if xyz_in_arcstring(xyz, self) {
+            if point_is_along_arcstring(xyz, self) {
                 return true;
             }
         }
@@ -742,20 +812,24 @@ impl GeometricOperations<MultiSphericalPoint> for ArcString {
         let mut distances = vec![];
         for xyz in &other.xyzs {
             distances.extend((0..self.points.len() - 1).map(|index| {
-                arc_radians_over_sphere_to_point(
+                arc_closest_distance_to_point(
                     &self.points.xyzs[index],
                     &self.points.xyzs[index + 1],
                     xyz,
                 )
+                .1
             }));
 
             if self.closed {
                 // if the arcstring is closed, also add the midpoint of the final closing arc
-                distances.push(arc_radians_over_sphere_to_point(
-                    &self.points.xyzs[self.points.len() - 1],
-                    &self.points.xyzs[0],
-                    xyz,
-                ));
+                distances.push(
+                    arc_closest_distance_to_point(
+                        &self.points.xyzs[self.points.len() - 1],
+                        &self.points.xyzs[0],
+                        xyz,
+                    )
+                    .1,
+                );
             }
         }
 
@@ -817,10 +891,10 @@ impl GeometricRelationships<Self> for ArcString {
         }
 
         // we can't use the Bentley-Ottmann sweep-line algorithm here :/
-        // because a sphere is an enclosed infinite space so there's no good way to sort by longitude
+        // because a sphere is an enclosed connected space so there's no good way to sort by longitude
         // so I guess the best we can do instead is use brute-force
         for arc_index in 0..self.points.len() - if self.closed { 0 } else { 1 } {
-            if arc_crosses_arcstring(
+            if arc_crossings_with_arcstring(
                 (
                     &self.points.xyzs[arc_index],
                     &self.points.xyzs[if arc_index < self.points.len() - 1 {
@@ -830,7 +904,9 @@ impl GeometricRelationships<Self> for ArcString {
                     }],
                 ),
                 other,
-            ) {
+            )
+            .is_some()
+            {
                 return true;
             }
         }
@@ -842,7 +918,7 @@ impl GeometricRelationships<Self> for ArcString {
         self.points
             .xyzs
             .iter()
-            .all(|xyz| xyz_in_arcstring(xyz, other))
+            .all(|xyz| point_is_along_arcstring(xyz, other))
     }
 
     fn contains(&self, other: &Self) -> bool {
@@ -868,7 +944,9 @@ impl GeometricRelationships<Self> for ArcString {
                 );
 
                 // TODO: handle case where an arcstring has both endpoints on the other arcstring, but cuts a corner...
-                if xyz_in_arcstring(&arc.0, other) && xyz_in_arcstring(&arc.1, other) {
+                if point_is_along_arcstring(&arc.0, other)
+                    && point_is_along_arcstring(&arc.1, other)
+                {
                     return true;
                 }
             }
@@ -917,7 +995,7 @@ impl GeometricOperations<ArcString> for ArcString {
                     }],
                 );
 
-                if let Some(point) = xyz_two_arc_crossing(arc, other_arc) {
+                if let Some(point) = arcs_crossing(arc, other_arc) {
                     intersections.push(point);
                 }
             }

--- a/src/edgegraph.rs
+++ b/src/edgegraph.rs
@@ -149,7 +149,9 @@ where
             }
 
             if node_index >= &num_nodes {
-                panic!("new node attempts to reference invalid index {node_index} (out of {num_nodes} nodes)");
+                panic!(
+                    "new node attempts to reference invalid index {node_index} (out of {num_nodes} nodes)"
+                );
             }
 
             self.nodes[*node_index]
@@ -234,7 +236,7 @@ where
         let mut removed = vec![];
         for (node_index, node) in self.nodes.to_owned().iter().enumerate() {
             for edge_node_index in node.edges.keys() {
-                if crate::sphericalpoint::arc_distance_over_sphere_radians(
+                if crate::sphericalpoint::arc_distance_over_sphere(
                     &node.xyz,
                     &self.nodes[*edge_node_index].xyz,
                 ) < tolerance
@@ -275,7 +277,7 @@ where
                     let end_node = &nodes[*end_node_index];
                     // check if any other nodes lie on this edge...
                     for (middle_node_index, middle_node) in self.nodes.iter().enumerate() {
-                        if crate::sphericalpoint::xyzs_collinear(
+                        if crate::sphericalpoint::xyzs_colinear(
                             &start_node.xyz,
                             &middle_node.xyz,
                             &end_node.xyz,
@@ -307,7 +309,7 @@ where
                             other_start_node.edges.iter()
                         {
                             let other_end_node = &self.nodes[*other_end_node_index];
-                            if let Some(crossing) = crate::arcstring::xyz_two_arc_crossing(
+                            if let Some(crossing) = crate::arcstring::arcs_crossing(
                                 (&start_node.xyz, &end_node.xyz),
                                 (&other_start_node.xyz, &other_end_node.xyz),
                             ) {
@@ -507,7 +509,7 @@ fn trace_polygons(
             .map(|(edge_node_index, edge_sources)| {
                 (
                     (edge_node_index, edge_sources),
-                    crate::sphericalpoint::xyz_two_arc_angle_radians(
+                    crate::sphericalpoint::xyz_two_arc_angle(
                         &previous_node.xyz,
                         &working_node.xyz,
                         &nodes[*edge_node_index].xyz,
@@ -549,20 +551,22 @@ fn trace_polygons(
         } else {
             // if the traced polygon is closed...
             if polygon_node_indices[0] == polygon_node_indices[polygon_node_indices.len() - 1] {
-                vec![crate::sphericalpolygon::SphericalPolygon::try_new(
-                    crate::arcstring::ArcString::try_from(
-                        crate::sphericalpoint::MultiSphericalPoint::try_from(
-                            polygon_node_indices
-                                .iter()
-                                .map(|node_index| nodes[*node_index].xyz)
-                                .collect::<Vec<[f64; 3]>>(),
+                vec![
+                    crate::sphericalpolygon::SphericalPolygon::try_new(
+                        crate::arcstring::ArcString::try_from(
+                            crate::sphericalpoint::MultiSphericalPoint::try_from(
+                                polygon_node_indices
+                                    .iter()
+                                    .map(|node_index| nodes[*node_index].xyz)
+                                    .collect::<Vec<[f64; 3]>>(),
+                            )
+                            .unwrap(),
                         )
                         .unwrap(),
+                        None,
                     )
                     .unwrap(),
-                    None,
-                )
-                .unwrap()]
+                ]
             } else {
                 vec![]
             }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -114,7 +114,7 @@ pub trait GeometricOperations<O: Geometry = Self, S: Geometry = Self> {
     ///
     /// NOTE: this function is NOT rigorous;
     /// it will ONLY return the lower order of geometry being compared
-    /// and will NOT handle touching, collinear overlap, or degenerate cases
+    /// and will NOT handle touching, colinear overlap, or degenerate cases
     fn intersection(&self, other: &O) -> Option<impl Geometry>;
 
     /// split this geometry into a multi-geometry, at the crossing with the given geometry

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,11 @@ mod py_sphersgeo {
             self.into()
         }
 
+        #[getter]
+        fn get_antipode(&self) -> SphericalPoint {
+            self.antipode()
+        }
+
         #[pyo3(name = "two_arc_angle")]
         fn py_two_arc_angle(
             &self,
@@ -101,13 +106,13 @@ mod py_sphersgeo {
             Ok(self.two_arc_angle(&Self::py_new(start)?, &Self::py_new(end)?))
         }
 
-        #[pyo3(name = "collinear")]
-        fn py_collinear(
+        #[pyo3(name = "colinear")]
+        fn py_colinear(
             &self,
             a: PySphericalPointInputs,
             b: PySphericalPointInputs,
         ) -> PyResult<bool> {
-            Ok(self.collinear(&Self::py_new(a)?, &Self::py_new(b)?))
+            Ok(self.colinear(&Self::py_new(a)?, &Self::py_new(b)?))
         }
 
         #[pyo3(name = "is_clockwise_turn")]
@@ -1493,11 +1498,6 @@ mod py_sphersgeo {
         #[getter]
         fn get_is_convex(&self) -> bool {
             self.is_convex()
-        }
-
-        #[getter]
-        fn get_is_clockwise(&self) -> bool {
-            self.is_clockwise()
         }
 
         #[pyo3(name = "simplify")]

--- a/src/python/sphersgeo/sphersgeo.pyi
+++ b/src/python/sphersgeo/sphersgeo.pyi
@@ -26,11 +26,14 @@ class SphericalPoint:
         """convert this point on the sphere to angular coordinates"""
         ...
 
+    @property
+    def antipode(self) -> SphericalPoint: ...
+
     def two_arc_angle(self, a: SphericalPoint, b: SphericalPoint) -> float:
         """angle on the sphere between this point and two other points"""
         ...
 
-    def collinear(self, a: SphericalPoint, b: SphericalPoint) -> bool:
+    def colinear(self, a: SphericalPoint, b: SphericalPoint) -> bool:
         """whether this point shares a line with two other points"""
         ...
 
@@ -745,13 +748,7 @@ class SphericalPolygon:
         ...
 
     @property
-    def antipode(self) -> bool: ...
-    @property
     def inverse(self) -> SphericalPolygon: ...
-    @property
-    def is_clockwise(self) -> bool:
-        """whether the points in this polygon are in clockwise order"""
-        ...
 
     def simplify(self):
         """remove redundant vertices that already lie along the boundary"""

--- a/src/sphericalpoint.rs
+++ b/src/sphericalpoint.rs
@@ -10,7 +10,7 @@ use std::{
 use pyo3::prelude::*;
 
 #[cfg(feature = "ndarray")]
-use ndarray::{array, Array1, Array2, ArrayView1, Axis};
+use ndarray::{Array1, Array2, ArrayView1, Axis, array};
 
 pub fn linspace(x0: f64, xend: f64, n: usize) -> Vec<f64> {
     let dx = (xend - x0) / ((n - 1) as f64);
@@ -150,8 +150,8 @@ fn xyz_to_lonlat(xyz: &[f64; 3]) -> [f64; 2] {
     [lon.to_degrees(), lat.to_degrees()]
 }
 
-/// rotate xyz vector by theta angle around another xyz vector
-fn xyz_rotate_around_radians(a: &[f64; 3], b: &[f64; 3], theta: &f64) -> [f64; 3] {
+/// rotate xyz vector by theta angle (in radians) around another xyz vector
+fn xyz_rotate_around(a: &[f64; 3], b: &[f64; 3], theta: &f64) -> [f64; 3] {
     let theta_sin = theta.sin();
     let theta_cos = theta.cos();
 
@@ -192,7 +192,7 @@ fn haversine_distance_over_sphere_radians(a: &[f64; 2], b: &[f64; 2]) -> f64 {
 /// References
 /// ----------
 /// - https://www.mathforengineers.com/math-calculators/angle-between-two-vectors-in-spherical-coordinates.html
-pub fn arc_distance_over_sphere_radians(a: &[f64; 3], b: &[f64; 3]) -> f64 {
+pub fn arc_distance_over_sphere(a: &[f64; 3], b: &[f64; 3]) -> f64 {
     if xyz_eq(a, b) {
         0.0
     } else {
@@ -210,14 +210,16 @@ pub fn arc_distance_over_sphere_radians(a: &[f64; 3], b: &[f64; 3]) -> f64 {
     }
 }
 
-/// given three XYZ vector points on the sphere (`a`, `b`, and `c`), retrieve the angle at `b` formed by arcs `ab` and `bc`
+/// given three XYZ vector points on the sphere (`a`, `b`, and `c`),
+/// retrieve the angle in radians at `b` formed by arcs `ab` and `bc`
+/// (the smaller angle irrespective of turn orientation)
 ///
 ///     cos(ca) = cos(bc) * cos(ab) + sin(bc) * sin(ab) * cos(b)
 ///
 /// References:
 /// - Miller, Robert D. Computing the area of a spherical polygon. Graphics Gems IV. p132. 1994. Academic Press. doi:10.5555/180895.180907
 ///   `pdf <https://www.google.com/books/edition/Graphics_Gems_IV/CCqzMm_-WucC?hl=en&gbpv=1&dq=Graphics%20Gems%20IV.%20p132&pg=PA133&printsec=frontcover>`_
-pub fn xyz_two_arc_angle_radians(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> f64 {
+pub fn xyz_two_arc_angle(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> f64 {
     let tolerance = 2e-8;
 
     // let abx = xyz_cross(&a, &b);
@@ -243,9 +245,9 @@ pub fn xyz_two_arc_angle_radians(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> f6
     //     }
     // }
 
-    let ab = arc_distance_over_sphere_radians(a, b);
-    let bc = arc_distance_over_sphere_radians(b, c);
-    let ca = arc_distance_over_sphere_radians(c, a);
+    let ab = arc_distance_over_sphere(a, b);
+    let bc = arc_distance_over_sphere(b, c);
+    let ca = arc_distance_over_sphere(c, a);
 
     if ab < tolerance || bc < tolerance || ca < tolerance {
         // if any side of the triangle is negligibly small
@@ -275,15 +277,15 @@ fn xyz_two_arc_is_clockwise(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> bool {
 }
 
 /// whether the three xyz points exist on the same great-circle arc
-pub fn xyzs_collinear(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> bool {
+pub fn xyzs_colinear(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> bool {
     if xyz_eq(a, b) || xyz_eq(b, c) {
         true
     } else {
         let tolerance = 2e-8;
 
-        let abc = xyz_two_arc_angle_radians(a, b, c);
-        let cab = xyz_two_arc_angle_radians(c, a, b);
-        let bca = xyz_two_arc_angle_radians(b, c, a);
+        let abc = xyz_two_arc_angle(a, b, c);
+        let cab = xyz_two_arc_angle(c, a, b);
+        let bca = xyz_two_arc_angle(b, c, a);
 
         abc < tolerance
             || cab < tolerance
@@ -305,7 +307,7 @@ pub fn arc_interpolate_points(
     n: usize,
 ) -> Result<Vec<[f64; 3]>, String> {
     let n = if n < 2 { 2 } else { n };
-    let omega = arc_distance_over_sphere_radians(a, b);
+    let omega = arc_distance_over_sphere(a, b);
 
     let mut offsets = linspace(0.0, 1.0, n);
     offsets = if omega == 0.0 {
@@ -557,13 +559,19 @@ impl SphericalPoint {
         Self::from([x, y, z])
     }
 
+    pub fn antipode(&self) -> SphericalPoint {
+        SphericalPoint {
+            xyz: xyz_sub_f64(&self.xyz, &1.0),
+        }
+    }
+
     pub fn two_arc_angle(&self, start: &SphericalPoint, end: &SphericalPoint) -> f64 {
-        xyz_two_arc_angle_radians(&start.xyz, &self.xyz, &end.xyz).to_degrees()
+        xyz_two_arc_angle(&start.xyz, &self.xyz, &end.xyz).to_degrees()
     }
 
     /// whether this point shares a line with two other points
-    pub fn collinear(&self, a: &SphericalPoint, b: &SphericalPoint) -> bool {
-        xyzs_collinear(&a.xyz, &self.xyz, &b.xyz)
+    pub fn colinear(&self, a: &SphericalPoint, b: &SphericalPoint) -> bool {
+        xyzs_colinear(&a.xyz, &self.xyz, &b.xyz)
     }
 
     /// whether the angle formed between this point and two other points is a clockwise turn
@@ -593,7 +601,7 @@ impl SphericalPoint {
 
     /// rotate this xyz vector by theta angle around another xyz vector
     pub fn vector_rotate_around(&self, other: &Self, theta: &f64) -> Self {
-        Self::from(xyz_rotate_around_radians(
+        Self::from(xyz_rotate_around(
             &self.xyz,
             &other.xyz,
             &theta.to_radians(),
@@ -675,7 +683,7 @@ impl GeometricOperations<Self> for SphericalPoint {
     }
 
     fn distance(&self, other: &Self) -> f64 {
-        arc_distance_over_sphere_radians(&self.xyz, &other.xyz).to_degrees()
+        arc_distance_over_sphere(&self.xyz, &other.xyz).to_degrees()
     }
 
     fn intersection(&self, other: &Self) -> Option<SphericalPoint> {
@@ -1495,7 +1503,7 @@ impl GeometricRelationships<crate::arcstring::ArcString> for MultiSphericalPoint
     fn intersects(&self, other: &crate::arcstring::ArcString) -> bool {
         self.xyzs
             .iter()
-            .any(|xyz| crate::arcstring::xyz_in_arcstring(xyz, other))
+            .any(|xyz| crate::arcstring::point_is_along_arcstring(xyz, other))
     }
 
     fn touches(&self, other: &crate::arcstring::ArcString) -> bool {
@@ -1525,7 +1533,7 @@ impl GeometricOperations<crate::arcstring::ArcString, SphericalPoint> for MultiS
             self.xyzs
                 .iter()
                 .filter_map(|xyz| {
-                    if crate::arcstring::xyz_in_arcstring(xyz, other) {
+                    if crate::arcstring::point_is_along_arcstring(xyz, other) {
                         Some(*xyz)
                     } else {
                         None
@@ -1622,10 +1630,10 @@ impl GeometricRelationships<crate::sphericalpolygon::MultiSphericalPolygon>
         // TODO: find a better algorithm than brute-force; perhaps we can keep a kdtree of centroids for multigeometries?
         self.xyzs.iter().all(|xyz| {
             other.polygons.iter().any(|polygon| {
-                crate::sphericalpolygon::xyz_in_polygon_boundary(
+                crate::arcstring::points_are_on_same_side(
                     xyz,
                     &polygon.interior_point.xyz,
-                    &polygon.boundary.points.xyzs,
+                    &polygon.boundary,
                 )
             })
         })
@@ -1657,27 +1665,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_xyzs_distance_over_sphere_radians() {
+    fn test_xyzs_distance_over_sphere() {
         let a = [0.0, 0.0, 1.0];
         let b = [0.0, 0.0, -1.0];
         let c = [1.0, 1.0, 0.0];
         let d = [1.0, -1.0, 0.0];
 
-        assert_eq!(
-            arc_distance_over_sphere_radians(&a, &b),
-            xyz_dot(&a, &b).acos()
-        );
-        assert_eq!(
-            arc_distance_over_sphere_radians(&b, &c),
-            xyz_dot(&b, &c).acos()
-        );
-        assert_eq!(
-            arc_distance_over_sphere_radians(&c, &d),
-            xyz_dot(&c, &d).acos()
-        );
-        assert_eq!(
-            arc_distance_over_sphere_radians(&d, &a),
-            xyz_dot(&d, &a).acos()
-        );
+        assert_eq!(arc_distance_over_sphere(&a, &b), xyz_dot(&a, &b).acos());
+        assert_eq!(arc_distance_over_sphere(&b, &c), xyz_dot(&b, &c).acos());
+        assert_eq!(arc_distance_over_sphere(&c, &d), xyz_dot(&c, &d).acos());
+        assert_eq!(arc_distance_over_sphere(&d, &a), xyz_dot(&d, &a).acos());
     }
 }

--- a/src/sphericalpolygon.rs
+++ b/src/sphericalpolygon.rs
@@ -1,13 +1,10 @@
 use crate::{
-    arcstring::{xyz_two_arc_crossing, ArcString, MultiArcString},
+    arcstring::{ArcString, MultiArcString, points_are_on_same_side, xyzs_turn_orientations},
     edgegraph::EdgeGraph,
     geometry::{
         GeometricOperations, GeometricRelationships, Geometry, GeometryCollection, MultiGeometry,
     },
-    sphericalpoint::{
-        xyz_add_xyz, xyz_cross, xyz_div_f64, xyz_mul_xyz, xyz_sub_xyz, xyz_sum,
-        xyz_two_arc_angle_radians, xyzs_mean, xyzs_sum, MultiSphericalPoint, SphericalPoint,
-    },
+    sphericalpoint::{MultiSphericalPoint, SphericalPoint, xyz_div_f64, xyzs_sum},
 };
 use std::{
     cmp::Ordering,
@@ -19,7 +16,7 @@ use std::{
 #[cfg(feature = "py")]
 use pyo3::prelude::*;
 
-/// surface area of a triangle on the sphere via Girard's theorum
+/// surface area of a triangle on the sphere via Girard's theorem
 ///
 ///     θ_1 + θ_2 + θ_3 − π
 ///
@@ -28,16 +25,16 @@ use pyo3::prelude::*;
 /// - Klain, D. A. (2019). A probabilistic proof of the spherical excess formula (No. arXiv:1909.04505). arXiv. https://doi.org/10.48550/arXiv.1909.04505
 /// - Miller, Robert D. Computing the area of a spherical polygon. Graphics Gems IV. 1994. Academic Press. doi:10.5555/180895.180907
 ///   `pdf <https://www.google.com/books/edition/Graphics_Gems_IV/CCqzMm_-WucC?hl=en&gbpv=1&dq=Graphics%20Gems%20IV.%20p132&pg=PA133&printsec=frontcover>`_
-pub fn spherical_triangle_area(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> f64 {
+pub fn area_of_triangle(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> f64 {
     // xyz_two_arc_angle_radians(c, a, b)
     //     + xyz_two_arc_angle_radians(a, b, c)
     //     + xyz_two_arc_angle_radians(b, c, a)
     //     - std::f64::consts::PI
 
-    // redefine Girard's theorum to avoid domain errors
-    let ab = crate::sphericalpoint::arc_distance_over_sphere_radians(a, b);
-    let bc = crate::sphericalpoint::arc_distance_over_sphere_radians(b, c);
-    let ca = crate::sphericalpoint::arc_distance_over_sphere_radians(c, a);
+    // redefine Girard's theorem to avoid domain errors
+    let ab = crate::sphericalpoint::arc_distance_over_sphere(a, b);
+    let bc = crate::sphericalpoint::arc_distance_over_sphere(b, c);
+    let ca = crate::sphericalpoint::arc_distance_over_sphere(c, a);
     let s = (ab + bc + ca) / 2.0;
 
     4.0 * ((s / 2.0).tan()
@@ -48,146 +45,200 @@ pub fn spherical_triangle_area(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3]) -> f64 
     .atan()
 }
 
-// use the classical even-crossings ray algorithm for point-in-polygon
-pub fn xyz_in_polygon_boundary(
-    xyz: &[f64; 3],
-    polygon_interior_xyz: &[f64; 3],
-    polygon_boundary_xyzs: &[[f64; 3]],
-) -> bool {
-    // record the number of times the ray intersects the exterior boundary arcstring
-    let mut crossings = 0;
-    for index in 0..polygon_boundary_xyzs.len() - 1 {
-        if xyz_two_arc_crossing(
-            (xyz, polygon_interior_xyz),
-            (
-                &polygon_boundary_xyzs[index],
-                &polygon_boundary_xyzs[index + 1],
-            ),
-        )
-        .is_some()
-        {
-            crossings += 1;
-        }
-    }
-
-    // if the number of crossings is even, the point is within the polygon's exterior
-    crossings % 2 == 0
+/// whether this polygon is convex, that is, all possible arcs between points inside the polygon never leave the enclosed space
+fn polygon_boundary_is_convex(boundary: &ArcString) -> bool {
+    // if all orientations are positive (left turns), the polygon is convex
+    boundary.points.xyzs.len() <= 4
+        || xyzs_turn_orientations(&boundary.points.xyzs, true)
+            .iter()
+            .all(|orientation| orientation < &0.0)
 }
 
-fn polygon_boundary_is_convex(xyzs: &[[f64; 3]]) -> bool {
-    // if all orientations are positive, the polygon is convex
-    let orient = orientation(xyzs);
-
-    let positive_dominant = orient.iter().sum::<f64>() > 0.0;
-    orient.iter().all(|orientation| {
-        if positive_dominant {
-            orientation > &0.0
-        } else {
-            orientation < &0.0
-        }
-    })
+fn centroid_of_polygon_boundary(boundary: &ArcString) -> SphericalPoint {
+    // see here https://www.javaspring.net/blog/how-can-you-find-the-centroid-of-a-concave-irregular-polygon-in-javascript/#step-by-step-calculation-in-javascript
+    todo!()
 }
 
-/// The normal vector to the two arcs containing a vertex points; outward
-/// from the sphere if the angle is clockwise, and inward if the angle is
-/// counter-clockwise. The sign of the inner product of the normal vector
-/// with the vertex tells you this. The polygon is ordered clockwise if
-/// the vertices are predominantly clockwise and counter-clockwise if
-/// the reverse.
-fn orientation(xyzs: &[[f64; 3]]) -> Vec<f64> {
-    (0..xyzs.len() - 2)
-        .map(|index| {
-            let a = xyzs[index];
-            let b = xyzs[index + 1];
-            let c = xyzs[index + 2];
-
-            xyz_sum(&xyz_mul_xyz(
-                &b,
-                &xyz_cross(&xyz_sub_xyz(&a, &b), &xyz_sub_xyz(&c, &b)),
-            ))
+/// vertex angles in radians to the left of the given polygon boundary
+fn vertex_angles_inside_polygon_boundary(boundary: &ArcString) -> Vec<f64> {
+    crate::arcstring::xyzs_turn_angles(&boundary.points.xyzs, true)
+        .into_iter()
+        .zip(xyzs_turn_orientations(&boundary.points.xyzs, true).iter())
+        .map(|(angle, orientation)| {
+            if orientation < &0.0 {
+                angle
+            } else {
+                // invert the angle to ensure it's the one on the left
+                (2.0 * std::f64::consts::PI) - angle
+            }
         })
-        .collect()
+        .collect::<Vec<f64>>()
 }
 
-fn centroid_from_polygon_boundary(xyzs: &Vec<[f64; 3]>) -> SphericalPoint {
-    let mut orient = orientation(xyzs);
+/// surface area of the polygon in square degrees
+///
+/// deconstructed into triangles via method described in Girard's Theorem
+///
+///     area = (sum_of_angles - (num_vertices - 2) * pi) * radius^2
+///
+/// References
+/// ----------
+/// - Toddhunter, I. (1886). Article 99. In Spherical Trigonometry: For the Use of Colleges and Schools (pp. 73–74). print.
+fn area_inside_polygon_boundary(boundary: &ArcString) -> f64 {
+    let interior_angles = vertex_angles_inside_polygon_boundary(boundary);
 
-    // make positive orientation the dominant
-    if orient.iter().sum::<f64>() < 0.0 {
-        orient = orient.iter().map(|value| value * -1.0).collect();
-    }
-
-    // if all orientations are positive, the polygon is convex
-    SphericalPoint::from(if orient.iter().all(|orientation| orientation > &0.0) {
-        // the centroid of a convex polygon is the simple mean of its vertices
-        xyzs_mean(xyzs)
-    } else {
-        // get the centroid of all midpoints between the endpoints of each convex triad (acute interior angle)
-        xyzs_mean(
-            &orient
-                .iter()
-                .enumerate()
-                .filter_map(|(index, orientation)| {
-                    if orientation > &0.0 {
-                        // midpoint between endpoint of convex triad (acute interior angle)
-                        Some(xyz_div_f64(
-                            &xyz_add_xyz(
-                                &xyzs[index],
-                                &xyzs[if index >= xyzs.len() - 2 {
-                                    index - xyzs.len()
-                                } else {
-                                    index
-                                } + 2],
-                            ),
-                            &2.0,
-                        ))
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<[f64; 3]>>(),
-        )
-    })
+    // sum the interior angles at each vertex,
+    // subtract pi for each vertex sans 2 (or four right angles),
+    // then convert from steradians to square degrees
+    (interior_angles.iter().sum::<f64>()
+        - ((interior_angles.len() - 2) as f64 * std::f64::consts::PI))
+        * 3282.8065632
 }
 
-/// choose an interior point from the smaller area of the two regions created by the given boundary
-fn interior_point_from_polygon_boundary(boundary: &ArcString) -> Result<SphericalPoint, String> {
-    let boundary_centroid = boundary.centroid();
+/// choose an interior point from the region to the left of the given boundary
+///
+/// assumes the boundary is closed
+fn find_point_inside_polygon_boundary(boundary: &ArcString) -> Result<SphericalPoint, String> {
+    let centroid_of_vertices = boundary.centroid();
 
-    if boundary.points.len() <= 4 {
-        Ok(boundary_centroid)
+    let orientations = xyzs_turn_orientations(&boundary.points.xyzs, true);
+    if boundary.points.xyzs.len() <= 4 || orientations.iter().all(|orientation| orientation < &0.0)
+    {
+        // if the polygon has 4 or less points,
+        // or is only comprised of left turns,
+        // then we can assume the centroid of vertices is inside, ezpz
+        Ok(centroid_of_vertices)
+    } else if orientations.iter().all(|orientation| orientation > &0.0) {
+        // if the polygon is ENTIRELY right turns
+        // (comprising an area of more than half the sphere)
+        // then we know that the antipode of the vertex centroid is inside, so again ezpz gg
+        Ok(centroid_of_vertices.antipode())
+    } else if orientations.iter().all(|orientation| orientation == &0.0) {
+        // if the polygon is a great circle on the sphere, bisecting it in two,
+        // then we can pick any point from the hemisphere on the left
+        todo!()
     } else {
-        // the centroid of the boundary arcstring COULD be outside the polygon if the boundary is not convex
+        // otherwise this is a concave polygon and we have to do some WORK
+        // to find a point guaranteed to be inside
 
-        // build two lists of triangle centroids, segregated by the exterior boundary of the polygon (we don't know which is which yet)
-        let mut side_a = vec![];
-        let mut side_b = vec![];
-        for index in 0..boundary.points.len() - 2 {
-            let triangle_centroid = SphericalPoint {
-                xyz: xyz_div_f64(
-                    &xyzs_sum(&boundary.points.xyzs[index..index + 3].to_vec()),
-                    &3.0,
-                ),
+        // iterate over groups of three vertices on the boundary to form triangles,
+        // the centroids of which can be either inside or outside the polygon.
+        // Keep track which side of the boundary each one is on
+        // (IMPORTANT: remember we don't know yet if the centroid of vertices is inside or outside)
+        let mut centroids_of_triangles = vec![];
+        let mut with_centroid_of_vertices = vec![];
+        for index in 0..boundary.points.len() {
+            let a = boundary.points.xyzs[if index > 0 {
+                index - 1
+            } else {
+                boundary.points.len() - 1
+            }];
+            let b = boundary.points.xyzs[index];
+            let c = boundary.points.xyzs[if index < boundary.points.len() - 1 {
+                index + 1
+            } else {
+                0
+            }];
+
+            let centroid_of_triangle = SphericalPoint {
+                xyz: xyz_div_f64(&xyzs_sum(&vec![a, b, c]), &3.0),
             };
 
-            if crate::arcstring::arc_crosses_arcstring(
-                (&triangle_centroid.xyz, &boundary_centroid.xyz),
+            with_centroid_of_vertices.push(points_are_on_same_side(
+                &centroid_of_triangle.xyz,
+                &centroid_of_vertices.xyz,
                 boundary,
-            ) {
-                side_a.push(triangle_centroid);
-            } else {
-                side_b.push(triangle_centroid);
-            }
+            ));
+            centroids_of_triangles.push(centroid_of_triangle)
         }
 
-        // assume there are always more interior triangles than exterior, due to the nature of the boundary being closed
-        match side_a.len().cmp(&side_b.len()) {
-            Ordering::Less => Ok(side_b[0].to_owned()),
-            Ordering::Equal => Err(String::from(
-                "cannot infer an interior point from two equal hemispheres!",
-            )),
-            Ordering::Greater => Ok(side_a[0].to_owned()),
-        }
+        // If the polygon is majorly left turns (counterclockwise)
+        // then we need a triangle centroid from a left turn.
+        // The opposite (from a right turn) for majorly right turns (clockwise).
+        let is_clockwise = orientations.iter().sum::<f64>() > 0.0;
+
+        // Then we'll simply need to compare the areas of each side.
+        // This is where it gets dodgy;
+        // I figure we can ROUGHLY tell which side has the greater area
+        // by comparing the interior angles of triangles with centroids on either side...
+        //
+        // TODO validate this by testing with a polygon in the shape of a gulper eel
+        let interior_angles = vertex_angles_inside_polygon_boundary(boundary);
+        let sum_angles_with_centroid_of_vertices = interior_angles
+            .iter()
+            .zip(with_centroid_of_vertices.iter())
+            .filter_map(|(angle, on_same_side_as_centroid_of_vertices)| {
+                if on_same_side_as_centroid_of_vertices == &true {
+                    Some(angle)
+                } else {
+                    None
+                }
+            })
+            .sum::<f64>();
+        let sum_angles_without_centroid_of_vertices = interior_angles
+            .iter()
+            .zip(with_centroid_of_vertices.iter())
+            .filter_map(|(angle, on_same_side_as_centroid_of_vertices)| {
+                if on_same_side_as_centroid_of_vertices == &false {
+                    Some(angle)
+                } else {
+                    None
+                }
+            })
+            .sum::<f64>();
+
+        // For a counterclockwise polygon,
+        // we need to pick a triangle centroid from the side with the LESSER area.
+        // The opposite (greater area) for a clockwise polygon.
+        //
+        // here we're making the assumption that
+        // there will always be a triangle whose centroid is inside the polygon
+        let assumption_is_wrong_message = String::from(
+            "apparently no triangles exist along the boundary with a centroid inside the polygon.",
+        );
+        let cannot_infer_error_message = if sum_angles_with_centroid_of_vertices
+            > sum_angles_without_centroid_of_vertices
+        {
+            if !is_clockwise {
+                return Ok(centroid_of_vertices);
+            } else {
+                for (centroid_of_triangle, same_side_as_centroid_of_vertices) in
+                    centroids_of_triangles
+                        .iter()
+                        .zip(with_centroid_of_vertices.iter())
+                {
+                    if same_side_as_centroid_of_vertices == &false {
+                        return Ok(centroid_of_triangle.to_owned());
+                    }
+                }
+
+                assumption_is_wrong_message
+            }
+        } else if sum_angles_without_centroid_of_vertices > sum_angles_with_centroid_of_vertices {
+            if is_clockwise {
+                return Ok(centroid_of_vertices);
+            } else {
+                for (centroid_of_triangle, same_side_as_centroid_of_vertices) in
+                    centroids_of_triangles
+                        .iter()
+                        .zip(with_centroid_of_vertices.iter())
+                {
+                    if same_side_as_centroid_of_vertices == &false {
+                        return Ok(centroid_of_triangle.to_owned());
+                    }
+                }
+
+                assumption_is_wrong_message
+            }
+        } else {
+            format!(
+                "triangles along the boundary of this polygon have equal turn angles ({sum_angles_with_centroid_of_vertices} == {sum_angles_without_centroid_of_vertices})"
+            )
+        };
+
+        Err(format!(
+            "Cannot infer an interior point automatically; {cannot_infer_error_message}. Please provide a point known to be inside this polygon."
+        ))
     }
 }
 
@@ -227,7 +278,7 @@ impl SphericalPolygon {
             let interior_point = if let Some(interior_point) = interior_point {
                 interior_point
             } else {
-                interior_point_from_polygon_boundary(&boundary)?
+                find_point_inside_polygon_boundary(&boundary)?
             };
 
             Ok(Self {
@@ -283,14 +334,9 @@ impl SphericalPolygon {
         .unwrap()
     }
 
-    /// whether this polygon is convex, that is, all possible arcs between points inside the polygon can never leave the enclosed space
+    /// whether this polygon is convex, that is, all possible arcs between points inside the polygon never leave the enclosed space
     pub fn is_convex(&self) -> bool {
-        polygon_boundary_is_convex(&self.boundary.points.xyzs)
-    }
-
-    /// whether the points in this polygon are in clockwise order
-    pub fn is_clockwise(&self) -> bool {
-        orientation(&self.boundary.points.xyzs).iter().sum::<f64>() > 0.0
+        polygon_boundary_is_convex(&self.boundary)
     }
 
     /// remove redundant vertices that already lie along the boundary
@@ -321,55 +367,16 @@ impl Geometry for SphericalPolygon {
     }
 
     fn centroid(&self) -> crate::sphericalpoint::SphericalPoint {
-        centroid_from_polygon_boundary(&self.boundary.points.xyzs)
+        centroid_of_polygon_boundary(&self.boundary)
     }
 
     fn convex_hull(&self) -> Option<SphericalPolygon> {
         self.boundary.convex_hull()
     }
 
-    /// surface area of this polygon
-    ///
-    /// deconstructs into triangles using method described at https://www.math.csi.cuny.edu/abhijit/623/spherical-triangle.pdf
+    /// surface area of the polygon in square degrees
     fn area(&self) -> f64 {
-        // calculate the interior angles of the polygon comprised of the given points
-        let angles_radians = (0..self.boundary.points.len())
-            .map(|index| {
-                let triangle = vec![
-                    self.boundary.points.xyzs[index],
-                    self.boundary.points.xyzs[index + 1
-                        - if index >= self.boundary.points.xyzs.len() - 1 {
-                            self.boundary.points.xyzs.len()
-                        } else {
-                            0
-                        }],
-                    self.boundary.points.xyzs[index + 2
-                        - if index >= self.boundary.points.xyzs.len() - 2 {
-                            self.boundary.points.xyzs.len()
-                        } else {
-                            0
-                        }],
-                ];
-
-                let angle_radians =
-                    xyz_two_arc_angle_radians(&triangle[0], &triangle[1], &triangle[2]);
-
-                if crate::arcstring::arc_crosses_arcstring(
-                    (&xyzs_mean(&triangle), &self.interior_point.xyz),
-                    &self.boundary,
-                ) {
-                    // invert angle if it's on the exterior of the polygon
-                    2.0 * std::f64::consts::PI - angle_radians
-                } else {
-                    angle_radians
-                }
-            })
-            .collect::<Vec<f64>>();
-
-        // sum the interior angles and subtract a flat angle (pi) to get the spherical excess (area)
-        (angles_radians.iter().sum::<f64>()
-            - ((angles_radians.len() - 2) as f64 * std::f64::consts::PI))
-            .to_degrees()
+        area_inside_polygon_boundary(&self.boundary)
     }
 
     fn length(&self) -> f64 {
@@ -379,7 +386,7 @@ impl Geometry for SphericalPolygon {
                 (index + 1..self.boundary.points.len())
                     .filter_map(|other_index| {
                         if index != other_index {
-                            Some(crate::sphericalpoint::arc_distance_over_sphere_radians(
+                            Some(crate::sphericalpoint::arc_distance_over_sphere(
                                 &self.boundary.points.xyzs[index],
                                 &self.boundary.points.xyzs[other_index],
                             ))
@@ -407,20 +414,12 @@ impl GeometricRelationships<SphericalPoint> for SphericalPolygon {
 
     fn contains(&self, other: &SphericalPoint) -> bool {
         !self.boundary.contains(other)
-            && xyz_in_polygon_boundary(
-                &other.xyz,
-                &self.interior_point.xyz,
-                &self.boundary.points.xyzs,
-            )
+            && points_are_on_same_side(&other.xyz, &self.interior_point.xyz, &self.boundary)
     }
 
     fn covers(&self, other: &SphericalPoint) -> bool {
         self.boundary.contains(other)
-            || xyz_in_polygon_boundary(
-                &other.xyz,
-                &self.interior_point.xyz,
-                &self.boundary.points.xyzs,
-            )
+            || points_are_on_same_side(&other.xyz, &self.interior_point.xyz, &self.boundary)
     }
 }
 
@@ -450,14 +449,10 @@ impl GeometricOperations<SphericalPoint> for SphericalPolygon {
 
 impl GeometricRelationships<MultiSphericalPoint> for SphericalPolygon {
     fn intersects(&self, other: &MultiSphericalPoint) -> bool {
-        for xyz in &other.xyzs {
-            if xyz_in_polygon_boundary(xyz, &self.interior_point.xyz, &self.boundary.points.xyzs) {
-                return true;
-            }
-        }
-
-        // if no points returned true
-        false
+        return other
+            .xyzs
+            .iter()
+            .any(|point| points_are_on_same_side(point, &self.interior_point.xyz, &self.boundary));
     }
 
     fn touches(&self, other: &MultiSphericalPoint) -> bool {
@@ -465,39 +460,17 @@ impl GeometricRelationships<MultiSphericalPoint> for SphericalPolygon {
     }
 
     fn contains(&self, other: &MultiSphericalPoint) -> bool {
-        for xyz in &other.xyzs {
-            if crate::arcstring::xyz_in_arcstring(xyz, &self.boundary)
-                || !xyz_in_polygon_boundary(
-                    xyz,
-                    &self.interior_point.xyz,
-                    &self.boundary.points.xyzs,
-                )
-            {
-                // if the point is NOT within the polygon exterior
-                return false;
-            }
-        }
-
-        // if none of the points returned false
-        true
+        other.xyzs.iter().all(|point| {
+            !crate::arcstring::point_is_along_arcstring(point, &self.boundary)
+                && points_are_on_same_side(point, &self.interior_point.xyz, &self.boundary)
+        })
     }
 
     fn covers(&self, other: &MultiSphericalPoint) -> bool {
-        for xyz in &other.xyzs {
-            if !crate::arcstring::xyz_in_arcstring(xyz, &self.boundary)
-                && !xyz_in_polygon_boundary(
-                    xyz,
-                    &self.interior_point.xyz,
-                    &self.boundary.points.xyzs,
-                )
-            {
-                // if the point is NOT within the polygon exterior
-                return false;
-            }
-        }
-
-        // if none of the points returned false
-        true
+        other.xyzs.iter().all(|point| {
+            crate::arcstring::point_is_along_arcstring(point, &self.boundary)
+                || points_are_on_same_side(point, &self.interior_point.xyz, &self.boundary)
+        })
     }
 }
 
@@ -519,13 +492,11 @@ impl GeometricOperations<MultiSphericalPoint> for SphericalPolygon {
             other
                 .xyzs
                 .iter()
-                .filter_map(|xyz| {
-                    if xyz_in_polygon_boundary(
-                        xyz,
-                        &self.interior_point.xyz,
-                        &self.boundary.points.xyzs,
-                    ) {
-                        Some(*xyz)
+                .filter_map(|point| {
+                    if crate::arcstring::point_is_along_arcstring(point, &self.boundary)
+                        || points_are_on_same_side(point, &self.interior_point.xyz, &self.boundary)
+                    {
+                        Some(*point)
                     } else {
                         None
                     }
@@ -612,10 +583,10 @@ impl GeometricOperations<ArcString> for SphericalPolygon {
                     if let Some(crossing_segments) = polygon.intersection(&arcstring) {
                         for crossing_segment in crossing_segments.arcstrings {
                             // an arcstring only splits the polygon if it touches the boundary twice
-                            if crate::arcstring::xyz_in_arcstring(
+                            if crate::arcstring::point_is_along_arcstring(
                                 &crossing_segment.points.xyzs[0],
                                 &self.boundary,
-                            ) && crate::arcstring::xyz_in_arcstring(
+                            ) && crate::arcstring::point_is_along_arcstring(
                                 &crossing_segment.points.xyzs[crossing_segment.points.len() - 1],
                                 &self.boundary,
                             ) {

--- a/tests/test_sphericalpoint.py
+++ b/tests/test_sphericalpoint.py
@@ -376,37 +376,37 @@ def test_angle_nearly_coplanar():
     assert_allclose(angles[4], 0)
 
 
-def test_collinear():
+def test_colinear():
     # equatorial
     A = SphericalPoint((20.0, 0.0))
     B = SphericalPoint((0.0, 0.0))
     C = SphericalPoint((-20.0, 0.0))
-    assert A.collinear(B, C)
-    assert B.collinear(A, C)
-    assert C.collinear(A, B)
+    assert A.colinear(B, C)
+    assert B.colinear(A, C)
+    assert C.colinear(A, B)
 
     # meridianal
     A = SphericalPoint((0.0, 20.0))
     B = SphericalPoint((0.0, 0.0))
     C = SphericalPoint((0.0, -20.0))
-    assert A.collinear(B, C)
-    assert B.collinear(A, C)
-    assert C.collinear(A, B)
+    assert A.colinear(B, C)
+    assert B.colinear(A, C)
+    assert C.colinear(A, B)
 
-    # non-collinear points
+    # non-colinear points
     A = SphericalPoint((1.0, 0.0, 0.0))
     B = SphericalPoint((0.0, 1.0, 0.0))
     C = SphericalPoint((0.0, 0.0, 1.0))
-    assert not B.collinear(A, C)
+    assert not B.colinear(A, C)
 
     # mirrored
     A = SphericalPoint((1.0, 1.0, 1.0))
     B = SphericalPoint((0.0, 1.0, 0.0))
     C = SphericalPoint((-1.0, -1.0, -1.0))
-    assert B.collinear(A, C)
+    assert B.colinear(A, C)
 
     # points that equal each other
     A = SphericalPoint((1.0, 1.0, 1.0))
     B = SphericalPoint((0.0, 0.0, 0.0))
     C = SphericalPoint((1.0, 1.0, 1.0))
-    assert B.collinear(A, C)
+    assert B.colinear(A, C)

--- a/tests/test_sphericalpolygon.py
+++ b/tests/test_sphericalpolygon.py
@@ -13,18 +13,6 @@ from sphersgeo import (
 
 DATA_DIRECTORY = Path(__file__).parent / "data"
 
-TEST_POINTS = [
-    (0.88955854, 87.53857137),
-    (20.6543883, 87.60498618),
-    (343.19474696, 85.05565535),
-    (8.94286202, 85.50465173),
-    (27.38417684, 85.03404907),
-    (310.53503934, 88.56749324),
-    (0, 60),
-    (0, 90),
-    (12, 66),
-]
-
 
 def test_init():
     lonlats = [
@@ -77,64 +65,17 @@ def test_from_cone(lon, lat):
     assert_almost_equal(polygon.area, 312, decimal=0)
 
 
-@pytest.mark.parametrize(
-    "lonlats,is_clockwise",
-    [
-        (
-            [
-                (18.0, 6.0),
-                (20.0, 5.0),
-                (25.0, 5.0),
-                (25.0, 10.0),
-                (20.0, 10.0),
-                (18.0, 7.0),
-            ],
-            False,
-        ),
-        (
-            [
-                (18.0, 7.0),
-                (20.0, 10.0),
-                (25.0, 10.0),
-                (25.0, 5.0),
-                (20.0, 5.0),
-                (18.0, 6.0),
-            ],
-            True,
-        ),
-    ],
-)
-def test_is_clockwise(lonlats, is_clockwise):
-    poly = SphericalPolygon(lonlats)
-    assert poly.is_clockwise == is_clockwise
-
-
-def test_symmetric_difference():
-    a = SphericalPolygon([(20.0, 5.0), (25.0, 5.0), (25.0, 10.0), (20.0, 10.0)])
-    b = SphericalPolygon([(5.0, 5.0), (25.0, 5.0), (25.0, 15.0), (5.0, 15.0)])
-
-    symmetric_difference = a.symmetric_difference(b)
-
-    # TODO: add more validation
-    assert symmetric_difference is not None
-
-
-def test_overlap():
-    y_eps = 1e-8
-
-    def build_polygon(offset: float):
-        lonlats = np.array([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)])
-        lonlats[:, 0] += offset
-        lonlats[:, 1] += y_eps
-        poly = SphericalPolygon(lonlats)
-        return poly
-
-    first_poly = build_polygon(0.0)
-    for offset in range(11):
-        second_poly = build_polygon(offset)
-        overlap_area = first_poly.intersection(second_poly).area / first_poly.area
-        calculated_area = (10.0 - offset) / 10.0
-        assert abs(overlap_area - calculated_area) < 0.0005
+TEST_POINTS = [
+    (0.88955854, 87.53857137),
+    (20.6543883, 87.60498618),
+    (343.19474696, 85.05565535),
+    (8.94286202, 85.50465173),
+    (27.38417684, 85.03404907),
+    (310.53503934, 88.56749324),
+    (0, 60),
+    (0, 90),
+    (12, 66),
+]
 
 
 @pytest.mark.parametrize("test_point", TEST_POINTS)
@@ -174,158 +115,163 @@ def test_from_wcs(test_point, rotation, bounding_box, pixel_shape):
     assert polygon.contains(SphericalPoint(test_point))
 
 
-def test_point_in_poly():
-    point = SphericalPoint((-0.27475449, 0.47588873, -0.83548781))
-    poly = SphericalPolygon(
-        (
-            [
-                (0.04821217, -0.29877206, 0.95310589),
-                (0.04451801, -0.47274119, 0.88007608),
-                (-0.14916503, -0.46369786, 0.87334649),
-                (-0.16101648, -0.29210164, 0.94273555),
-                (0.04821217, -0.29877206, 0.95310589),
-            ],
-            (-0.03416009, -0.36858623, 0.9289657),
-        )
-    )
-    assert not poly.contains(point)
+TEST_POLYGONS = [
+    (
+        [(90.0, 0.0), (0.0, 45.0), (0.0, -45.0)],
+        1.5707963267948968,
+        (35.2643897, 0.0),
+        True,
+    ),
+    (
+        [(90.0, 0.0), (0.0, 22.5), (0.0, -22.5)],
+        0.7853981633974486,
+        (33.155842, 0.0),
+        True,
+    ),
+    (
+        [(90.0, 0.0), (0.0, 11.25), (0.0, -11.25)],
+        0.39269908169872403,
+        (32.648859, 0.0),
+        True,
+    ),
+    (
+        [
+            (20.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 10.0),
+            (20.0, 10.0),
+        ],
+        0.007552428735220221,
+        (22.5, 7.502247),
+        True,
+    ),
+    (
+        [
+            (5.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 15.0),
+            (5.0, 15.0),
+        ],
+        0.06047687635308728,
+        (15.0, 10.122954),
+        True,
+    ),
+    (
+        [
+            (18.0, 6.0),
+            (20.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 10.0),
+            (20.0, 10.0),
+            (18.0, 7.0),
+        ],
+        0.009368119881222133,
+        (21.864038, 7.428367),
+        True,
+    ),
+    (
+        [
+            # clockwise (inverse polygon comprising most of the sphere)
+            (18.0, 7.0),
+            (20.0, 10.0),
+            (25.0, 10.0),
+            (25.0, 5.0),
+            (20.0, 5.0),
+            (18.0, 6.0),
+        ],
+        12.55700249447795,
+        (-158.135962, -7.428367),
+        False,
+    ),
+    (
+        [
+            (18.0, 6.0),
+            (20.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 10.0),
+            (20.0, 10.0),
+            (19.0, 8.0),  # concave vertex
+            (18.0, 7.0),
+        ],
+        0.009215352192799085,
+        (21.911468, 7.413186),
+        False,
+    ),
+    (
+        [
+            # clockwise (inverse polygon comprising most of the sphere)
+            (18.0, 7.0),
+            (19.0, 8.0),  # concave vertex
+            (20.0, 10.0),
+            (25.0, 10.0),
+            (25.0, 5.0),
+            (20.0, 5.0),
+            (18.0, 6.0),
+        ],
+        0.009215352192799085,
+        (-158.088532, -7.413186),
+        False,
+    ),
+    (
+        # nearly degenerate, from https://github.com/spacetelescope/spherical_geometry/issues/192
+        [
+            [21.18490548, 19.72227505],
+            [21.46931577, 7.44460937],
+            [21.73600364, -4.72309959],
+        ],
+        8.082013e-07,
+        (21.468642, 7.481543),
+        True,
+    ),
+]
 
 
-@pytest.mark.parametrize(
-    "lonlats,expected_area",
-    [
-        ([(90, 0), (0, 45), (0, -45)], 450.0),
-        ([(90, 0), (0, 22.5), (0, -22.5)], 675.0),
-        ([(90, 0), (0, 11.25), (0, -11.25)], 22.5),
-        (
-            np.array(
-                [
-                    (20.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 10.0),
-                    (20.0, 10.0),
-                ]
-            ),
-            0.43272229160307324,
-        ),
-        (
-            np.array(
-                [
-                    (5.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 15.0),
-                    (5.0, 15.0),
-                ]
-            ),
-            3.4650697731667437,
-        ),
-        (
-            np.array(
-                [
-                    (18.0, 6.0),
-                    (20.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 10.0),
-                    (20.0, 10.0),
-                    (18.0, 7.0),
-                ]
-            ),
-            54.50117948865602,
-        ),
-        (
-            np.array(
-                [
-                    (18.0, 7.0),
-                    (20.0, 10.0),
-                    (25.0, 10.0),
-                    (25.0, 5.0),
-                    (20.0, 5.0),
-                    (18.0, 6.0),
-                ]
-            ),
-            112.56362825102903,
-        ),
-        (
-            np.array(
-                [
-                    (18.0, 6.0),
-                    (20.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 10.0),
-                    (20.0, 10.0),
-                    (19.0, 8.0),  # concave point
-                    (18.0, 7.0),
-                ]
-            ),
-            54.49242654476835,
-        ),
-    ],
-)
-def test_area(lonlats, expected_area):
-    assert_almost_equal(SphericalPolygon(lonlats).area, expected_area)
+@pytest.mark.parametrize("polygon", TEST_POLYGONS)
+def test_area(polygon):
+    assert_almost_equal(SphericalPolygon(polygon[0]).area / 3282.8065632, polygon[1])
 
 
-@pytest.mark.parametrize(
-    "lonlats,expected_centroid_lonlat",
-    [
-        ([(90, 0), (0, 45), (0, -45)], (35.2643897, 0.0)),
-        ([(90, 0), (0, 22.5), (0, -22.5)], (28.4220791, 0.0)),
-        ([(90, 0), (0, 11.25), (0, -11.25)], (27.012286, 0.0)),
-        (
-            np.array(
-                [
-                    (20.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 10.0),
-                    (20.0, 10.0),
-                ]
-            ),
-            (22.5, 7.5070637),
-        ),
-        (
-            np.array(
-                [
-                    (5.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 15.0),
-                    (5.0, 15.0),
-                ]
-            ),
-            (15.0, 10.1510817),
-        ),
-        (
-            np.array(
-                [
-                    (18.0, 6.0),
-                    (20.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 10.0),
-                    (20.0, 10.0),
-                    (18.0, 7.0),
-                ]
-            ),
-            (21.4828013, 8.0147551),
-        ),
-        (
-            np.array(
-                [
-                    (18.0, 6.0),
-                    (20.0, 5.0),
-                    (25.0, 5.0),
-                    (25.0, 10.0),
-                    (20.0, 10.0),
-                    (19.0, 8.0),
-                    (18.0, 7.0),
-                ]
-            ),
-            (21.4828013, 8.0147551),
-        ),
-    ],
-)
-def test_centroid(lonlats, expected_centroid_lonlat):
-    poly = SphericalPolygon(lonlats)
+@pytest.mark.parametrize("polygon", TEST_POLYGONS)
+def test_centroid(polygon):
+    assert_almost_equal(SphericalPolygon(polygon[0]).centroid.lonlat, polygon[2])
 
-    assert_almost_equal(poly.centroid.lonlat, expected_centroid_lonlat)
+
+@pytest.mark.parametrize("polygon", TEST_POLYGONS)
+def test_is_convex(polygon):
+    assert SphericalPolygon(polygon[0]).is_convex == polygon[3]
+
+
+@pytest.mark.parametrize("polygon", TEST_POLYGONS)
+def test_contains_point(polygon):
+    assert SphericalPolygon(polygon[0]).contains(SphericalPoint(polygon[2]))
+
+
+def test_symmetric_difference():
+    a = SphericalPolygon([(20.0, 5.0), (25.0, 5.0), (25.0, 10.0), (20.0, 10.0)])
+    b = SphericalPolygon([(5.0, 5.0), (25.0, 5.0), (25.0, 15.0), (5.0, 15.0)])
+
+    symmetric_difference = a.symmetric_difference(b)
+
+    # TODO: add more validation
+    assert symmetric_difference is not None
+
+
+def test_overlap():
+    y_eps = 1e-8
+
+    def build_polygon(offset: float):
+        lonlats = np.array([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)])
+        lonlats[:, 0] += offset
+        lonlats[:, 1] += y_eps
+        poly = SphericalPolygon(lonlats)
+        return poly
+
+    first_poly = build_polygon(0.0)
+    for offset in range(11):
+        second_poly = build_polygon(offset)
+        overlap_area = first_poly.intersection(second_poly).area / first_poly.area
+        calculated_area = (10.0 - offset) / 10.0
+        assert abs(overlap_area - calculated_area) < 0.0005
 
 
 @pytest.mark.parametrize(
@@ -489,19 +435,3 @@ def test_convex_hull(lonlats, expected_area, expected_on_boundary):
 
     for b, r in zip(on_boundary, expected_on_boundary):
         assert b == r, "convex hull incorrect"
-
-
-def test_nearly_degenerate_polygon():
-    # from https://github.com/spacetelescope/spherical_geometry/issues/192
-
-    points = [
-        (0.87772279707663836, 0.34018023965617028, 0.33746125116734926),
-        (0.92276918091486326, 0.36291770695506587, 0.12956765310905877),
-        (0.92574575323628161, 0.36907299235098134, -0.082340310189372115),
-    ]
-
-    single = SphericalPolygon(points)
-    multi = MultiSphericalPolygon([points])
-
-    assert single.area > 0
-    assert multi.area > 0


### PR DESCRIPTION

<!-- If this PR addresses a JIRA ticket: -->
<!-- Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn) -->

<!-- If this PR will close an existing GitHub issue (that is not already attached to a JIRA ticket): -->
<!-- Closes # -->

<!-- Describe your changes here: -->

## Description

this has the advantage of fixing area calculation and also makes inferring an interior point much easier. I used `s2geometry` as a reference for relevant test values.

<!-- If you can't perform these tasks due to permissions, reach out to a maintainer. -->

## Tasks

- [x] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/sphersgeo/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
