### PR TITLE
move change log to its own `toctree` and distinguish Rust from Python install options

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,6 @@ build:
   os: ubuntu-lts-latest
   tools:
     python: latest
-  apt_packages:
-    - graphviz
   jobs:
     post_checkout:
       - git fetch --unshallow --tags

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     post_checkout:
       - git fetch --unshallow --tags
     pre_build:
-      - git describe --exact-match || towncrier build --keep
+      - git describe --exact-match || towncrier build --keep --version=dev
 
 python:
   install:

--- a/changes/14.docs.rst
+++ b/changes/14.docs.rst
@@ -1,0 +1,1 @@
+move change log to its own `toctree` and distinguish Rust from Python install options

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_inline_tabs",
 ]
 
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,17 @@ sphersgeo
 `sphersgeo <https://github.com/spacetelescope/sphersgeo>`_
 is an object-oriented spherical geometry package written in Rust with Python accessor classes and methods.
 
-.. code-block:: shell
+.. tab:: Python
+   
+   .. code-block:: shell
 
-   pip install sphersgeo
+      pip install sphersgeo
+
+.. tab:: Rust
+
+   .. code-block:: shell
+
+      cargo install --git https://github.com/spacetelescope/sphersgeo
 
 Planar geometry packages typically classify geometries into points, linestrings, and polygons
 (along with multi-geometry collections: multi-points, multi-linestrings, and multi-polygons).
@@ -27,7 +35,7 @@ Polygon     `SphericalPolygon`  MultiPolygon       `MultiSphericalPolygon`
 
 .. toctree::
    :maxdepth: 1
-   :caption: API
+   :caption: Python API
 
    sphericalpoint.rst
    arcstring.rst
@@ -35,5 +43,6 @@ Polygon     `SphericalPolygon`  MultiPolygon       `MultiSphericalPolygon`
 
 .. toctree::
    :maxdepth: 1
+   :caption: Other
 
    changes.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,8 +27,13 @@ Polygon     `SphericalPolygon`  MultiPolygon       `MultiSphericalPolygon`
 
 .. toctree::
    :maxdepth: 1
+   :caption: API
 
    sphericalpoint.rst
    arcstring.rst
    sphericalpolygon.rst
+
+.. toctree::
+   :maxdepth: 1
+
    changes.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,13 @@ dynamic = [
 ]
 
 [dependency-groups]
-docs = ["sphinx", "sphinx-autoapi", "sphinx-rtd-theme", "towncrier"]
+docs = [
+  "sphinx",
+  "sphinx-autoapi",
+  "sphinx_inline_tabs",
+  "sphinx-rtd-theme",
+  "towncrier"
+]
 test = ["gwcs", "pytest"]
 
 [build-system]


### PR DESCRIPTION
<!-- If this PR addresses a JIRA ticket: -->
<!-- Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn) -->

<!-- If this PR will close an existing GitHub issue (that is not already attached to a JIRA ticket): -->
<!-- Closes # -->

<!-- Describe your changes here: -->

## Description

move change log to its own toctree

<!-- If you can't perform these tasks due to permissions, reach out to a maintainer. -->

## Tasks

- [ ] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/sphersgeo/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
